### PR TITLE
updated for Nvidia

### DIFF
--- a/src/gpuStatsServer.py
+++ b/src/gpuStatsServer.py
@@ -1,4 +1,4 @@
-#!/bin/python3 -u
+#!/usr/bin/env python3
 
 import subprocess
 import traceback


### PR DESCRIPTION
run() function is now an infinite loop due to the thread terminating
after the subprocess finished, which results in undesired behaviour

Checks if there are any parameters in line to prevent index out of range issues when line is empty

Removed power draw data due to some cards not supporting (GTX 1050TI)

Removed space in header array due to KSysGuard not being able to use headers with spaces

Removed misleading finally block and moved print statement to catch block

Commented untested warning message