### PR TITLE
NVIDIA fixes

### DIFF
--- a/src/gpuStatsServer.py
+++ b/src/gpuStatsServer.py
@@ -118,10 +118,10 @@ class Nvidia:
 	def __init__(self, allGpu, mutex):
 		self.allGpu = allGpu
 		self.mutex = mutex
-		self.header = ['temperature', 'utilization.%', 'memory.%', 'pstate', 'power.draw.w', 'clocks.sm.mhz', 'clocks.memory.mhz', 'clocks.graphics.mhz']
+		self.header = ['index', 'temperature', 'utilization.%', 'memory.%', 'fan.speed', 'pstate', 'power.draw.w', 'clocks.sm.mhz', 'clocks.memory.mhz', 'clocks.graphics.mhz']
 
 	def getCommand(self):
-		return ["nvidia-smi", "--query-gpu=index,temperature.gpu,utilization.gpu,utilization.memory,pstate,power.draw,clocks.sm,clocks.mem,clocks.gr", "--format=csv", '-l1']
+		return ["nvidia-smi", "--query-gpu=index,temperature.gpu,utilization.gpu,utilization.memory,fan.speed,pstate,power.draw,clocks.sm,clocks.mem,clocks.gr", "--format=csv", '-l1']
 
 	def parseLine(self, line):
 		line = str(line)
@@ -137,8 +137,8 @@ class Nvidia:
 			# this should be the header
 			return
 		
-		if len(parameters) != 9:
-			print( "Nvidia parse line error: I am expecting 9 parameter but I got " + len(parameters) )
+		if len(parameters) != len(self.header):
+			print( "Nvidia parse line error: I am expecting "+len(self.header)+" parameter but I got " + len(parameters) )
 			return
 		
 		gpuName = "Nvidia." + parameters[0]


### PR DESCRIPTION
'index' was missing in header, but was queried with nvidia-smi.
The returned values were shifted by this and temperature for example always returned 0 (the gpu index).
I adjusted the parameter length check to match the return header.

I also added fan.speed to nvidia-smi, because I was missing it.