### PR TITLE
Fix to #29 Handle nvidia-smi output when blacklisting nvidia module

### DIFF
--- a/src/nvidia.py
+++ b/src/nvidia.py
@@ -16,7 +16,11 @@ class Nvidia:
         line = line[2:-3]
         
         parameters = [s for s in line.split(',') if s]
-        
+
+        # Fixes possible nvidia-smi cmd errors # 29
+        if len(parameters) == 0:
+            return
+
         if not parameters[0].isdigit():
             # this should be the header
             return


### PR DESCRIPTION
Fix to #29 by checking `Nvidia.parseLine()`'s `parameters` length before accessing the array.

This however does not address the possible intel side, as mentioned on the issue.